### PR TITLE
DiDi report bug

### DIFF
--- a/src/main/scala/com/intel/imllib/crf/nlp/Tagger.scala
+++ b/src/main/scala/com/intel/imllib/crf/nlp/Tagger.scala
@@ -264,7 +264,7 @@ private[nlp] class Tagger (
     if(nBest > 0) {
       //initialize nBest
       if(agenda.nonEmpty) agenda.clear()
-      val nodesTemp = nodes.slice((x.size - 1) * ySize, x.size * ySize - 1)
+      val nodesTemp = nodes.slice((x.size - 1) * ySize, x.size * ySize)
       var i = 0
       while (i < nodesTemp.length) {
         val n = nodesTemp(i)


### PR DESCRIPTION
Tagger.scala 代码中: parse函数，在处理nbest的时候，

    if(nBest > 0) {
      //initialize nBest
      if(agenda.nonEmpty) agenda.clear()
      val nodesTemp = nodes.slice((x.size - 1) * ySize, x.size * ySize - 1)        ————> slice函数指的是 不含结尾  x.size * ySize – 1， 所以该处有问题。正常情况应该是 val nodesTemp = nodes.slice((x.size - 1) * ySize, x.size * ySize)
      var i = 0
      while (i < nodesTemp.length) {
        val n = nodesTemp(i)
        agenda += QueueElement(n, - n.bestCost, - n.cost, null)
        i += 1
      }
 Li Xiangyang (lixiangyang@didichuxing.com) 