### PR TITLE
Fix initial weights generation.

### DIFF
--- a/src/main/scala/com/intel/imllib/ffm/classification/FFMWithAdag.scala
+++ b/src/main/scala/com/intel/imllib/ffm/classification/FFMWithAdag.scala
@@ -52,11 +52,11 @@ class FFMWithAdag(m: Int, n: Int, dim: (Boolean, Boolean, Int), n_iters: Int, et
   private def generateInitWeights(): Vector = {
     val (num_k0, num_k1) = (k0, k1) match {
       case (true, true) =>
-        (n, 1)
+        (1, n)
       case(true, false) =>
-        (n, 0)
+        (1, 0)
       case(false, true) =>
-        (0, 1)
+        (0, n)
       case(false, false) =>
         (0, 0)
     }


### PR DESCRIPTION
 - `k0` is global bias and has only 1 weight.
 - `k1` is one way interaction and has n weights.

Without this, using one way interaction results in `IndexOutOfBoundException`. 