### PR TITLE
Return probability in FFMModel predict

### DIFF
--- a/src/main/scala/com/intel/imllib/ffm/classification/FieldAwaredFactorizationMachine.scala
+++ b/src/main/scala/com/intel/imllib/ffm/classification/FieldAwaredFactorizationMachine.scala
@@ -144,7 +144,7 @@ class FFMModel(val numFeatures: Int,
       }
       i += 1
     }
-    t
+    1 / (1 + math.exp(-t)) 
   }
 
   override protected def formatVersion: String = "1.0"


### PR DESCRIPTION
In this PR, we move the probability calculation to FFMModel predict.
In the previous implementation, FFMModel.predict returns hyperthesis, user count the probability based on this value.

Signed-off-by: Vincent Xie <vincent.xie@intel.com>